### PR TITLE
Fix module path mismatch

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"fastchacha20"
+	"github.com/renatosaksanni/fastchacha20"
 
 	"golang.org/x/crypto/chacha20poly1305"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module fastchacha20
+module github.com/renatosaksanni/fastchacha20
 
 go 1.22.4
 


### PR DESCRIPTION
## Summary
- fix module path to match README
- update example `main.go` import

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68443d6248d48330be58be6052d3302c