### PR TITLE
Clarify XChaCha20 usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastChaCha20
 
-FastChaCha20 is a Go library that provides an optimized implementation of the **ChaCha20-Poly1305** encryption algorithm. It leverages Go's concurrency features to encrypt and decrypt data in parallel, enhancing performance for large data sets.
+FastChaCha20 is a Go library that provides an optimized implementation of the **XChaCha20-Poly1305** encryption algorithm. It leverages Go's concurrency features to encrypt and decrypt data in parallel, enhancing performance for large data sets. XChaCha20-Poly1305 uses a 24-byte nonce, so ensure you generate one of that length for each message.
 
 ## Table of Contents
 
@@ -175,6 +175,7 @@ go test -bench=. -benchtime=10s
 
 ## Security Considerations
 
+- **Nonce Size:** XChaCha20-Poly1305 requires a 24-byte nonce. This differs from the 12-byte nonce used with standard ChaCha20-Poly1305.
 - **Nonce Uniqueness:** Always use a unique nonce for each encryption operation with the same key.
 - **Chunk Index in AAD:** Including the chunk index in the Additional Authenticated Data (AAD) binds each chunk to its position.
 - **Avoid Reusing Nonces:** Reusing a nonce with the same key can completely break the security.
@@ -210,7 +211,7 @@ go test -bench=. -benchtime=10s
   rand.Read(data)
   ```
 
-- **Check Nonce Sizes:**
+  - **Check Nonce Sizes:** The AEAD expects a 24-byte nonce.
 
   ```go
   nonce := make([]byte, cipher.aead.NonceSize())

--- a/cipher.go
+++ b/cipher.go
@@ -14,7 +14,7 @@ type Cipher struct {
 
 // NewCipher creates a new Cipher instance with the provided key.
 func NewCipher(key []byte) (*Cipher, error) {
-	aead, err := chacha20poly1305.NewX(key) // For 192-bit nonces. Use New() for 96-bit nonces.
+	aead, err := chacha20poly1305.NewX(key) // XChaCha20-Poly1305 uses 24-byte nonces; use New() for 12-byte nonces.
 	if err != nil {
 		return nil, err
 	}

--- a/cipher_test.go
+++ b/cipher_test.go
@@ -26,7 +26,7 @@ func generateRandomNonce(t *testing.T, size int) []byte {
 func TestEncryptDecrypt(t *testing.T) {
 	// Generate random key and nonce
 	key := generateRandomKey(t, 32)     // 256-bit key
-	nonce := generateRandomNonce(t, 24) // 192-bit nonce (for ChaCha20-Poly1305)
+	nonce := generateRandomNonce(t, 24) // 24-byte nonce required by XChaCha20-Poly1305
 
 	cipher, err := NewCipher(key)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestInvalidNonceLength(t *testing.T) {
 	}
 
 	// Generate invalid nonce
-	invalidNonce := generateRandomNonce(t, 16) // Should be 24 bytes for ChaCha20-Poly1305
+	invalidNonce := generateRandomNonce(t, 16) // Should be 24 bytes for XChaCha20-Poly1305
 	plaintext := []byte("Test plaintext")
 	aad := []byte("AAD data")
 

--- a/parallel_test.go
+++ b/parallel_test.go
@@ -122,7 +122,7 @@ func TestDecryptWithModifiedCiphertext(t *testing.T) {
 }
 
 func TestInvalidKeySize(t *testing.T) {
-	key := make([]byte, 16) // Invalid key size for ChaCha20-Poly1305 (requires 32 bytes)
+	key := make([]byte, 16) // Invalid key size for XChaCha20-Poly1305 (requires 32 bytes)
 	if _, err := rand.Read(key); err != nil {
 		t.Fatalf("Failed to generate key: %v", err)
 	}


### PR DESCRIPTION
## Summary
- clarify that the library uses XChaCha20-Poly1305
- note 24-byte nonce requirement in README and shortcuts
- update comments in tests and cipher creation

## Testing
- `go test ./...` *(fails: `Get https://proxy.golang.org/...: Forbidden`)*

------
https://chatgpt.com/codex/tasks/task_e_68443ed5c66c8330b01e0688eb4b0e70