### PR TITLE
Fix HKDF length handling

### DIFF
--- a/key_derivation.go
+++ b/key_derivation.go
@@ -16,8 +16,13 @@ func hkdfExtract(salt, inputKeyMaterial []byte, hashFunc func() hash.Hash) []byt
 	return h.Sum(nil)
 }
 
-func hkdfExpand(prk, info []byte, length int, hashFunc func() hash.Hash) []byte {
-	n := (length + hashFunc().Size() - 1) / hashFunc().Size()
+func hkdfExpand(prk, info []byte, length int, hashFunc func() hash.Hash) ([]byte, error) {
+	hashLen := hashFunc().Size()
+	if length > 255*hashLen {
+		return nil, ErrInvalidLength
+	}
+
+	n := (length + hashLen - 1) / hashLen
 	var t []byte
 	var okm []byte
 	for i := 0; i < n; i++ {
@@ -27,11 +32,11 @@ func hkdfExpand(prk, info []byte, length int, hashFunc func() hash.Hash) []byte 
 		t = h.Sum(nil)
 		okm = append(okm, t...)
 	}
-	return okm[:length]
+	return okm[:length], nil
 }
 
 // DeriveKey generates a derived key from the input key material.
-func DeriveKey(salt, inputKeyMaterial, info []byte, length int) []byte {
+func DeriveKey(salt, inputKeyMaterial, info []byte, length int) ([]byte, error) {
 	prk := hkdfExtract(salt, inputKeyMaterial, sha256.New)
 	return hkdfExpand(prk, info, length, sha256.New)
 }

--- a/key_derivation_test.go
+++ b/key_derivation_test.go
@@ -20,7 +20,10 @@ func TestDeriveKeyRFC5869Case1(t *testing.T) {
 	info := decodeHex(t, "f0f1f2f3f4f5f6f7f8f9")
 
 	expected := decodeHex(t, "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865")
-	got := DeriveKey(salt, ikm, info, len(expected))
+	got, err := DeriveKey(salt, ikm, info, len(expected))
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
 
 	if !bytes.Equal(got, expected) {
 		t.Errorf("HKDF test vector case 1 mismatch\nexpected %x\ngot %x", expected, got)
@@ -44,7 +47,10 @@ func TestDeriveKeyRFC5869Case2(t *testing.T) {
 	}
 
 	expected := decodeHex(t, "b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71cc30c58179ec3e87c14c01d5c1f3434f1d87")
-	got := DeriveKey(salt, ikm, info, len(expected))
+	got, err := DeriveKey(salt, ikm, info, len(expected))
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
 
 	if !bytes.Equal(got, expected) {
 		t.Errorf("HKDF test vector case 2 mismatch\nexpected %x\ngot %x", expected, got)
@@ -57,7 +63,10 @@ func TestDeriveKeyRFC5869Case3(t *testing.T) {
 	var info []byte // nil info
 
 	expected := decodeHex(t, "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8")
-	got := DeriveKey(salt, ikm, info, len(expected))
+	got, err := DeriveKey(salt, ikm, info, len(expected))
+	if err != nil {
+		t.Fatalf("DeriveKey failed: %v", err)
+	}
 
 	if !bytes.Equal(got, expected) {
 		t.Errorf("HKDF test vector case 3 mismatch\nexpected %x\ngot %x", expected, got)

--- a/utils.go
+++ b/utils.go
@@ -6,4 +6,5 @@ import "errors"
 var (
 	ErrInvalidCiphertext = errors.New("ciphertext too short")
 	ErrInvalidMAC        = errors.New("invalid MAC")
+	ErrInvalidLength     = errors.New("length exceeds maximum allowed")
 )


### PR DESCRIPTION
## Summary
- validate requested HKDF length and return an error if it exceeds the limit
- add `ErrInvalidLength` sentinel error
- update HKDF tests for new error return

## Testing
- `go vet ./...` *(fails: module download forbidden)*
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684532a9ace88330a4786314a1dde440